### PR TITLE
debian/control: Atualizado os conflitos para Ubuntu 18.04.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,13 +6,13 @@ Build-Depends: debhelper
 
 Package: maratona-desktop-virtual
 Architecture: all
-Conflicts: libreoffice-core, thunderbird, unity-webapps-common, gnome-software
+Conflicts: libreoffice-core, thunderbird, gnome-software, aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support, libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez, gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd, cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell, ubuntu-web-launchers
 Depends: maratona-desktop, maratona-virtual-minimal
 Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux para máquina virtual
 
 Package: maratona-desktop
 Architecture: all
-Conflicts: libreoffice-core, thunderbird, unity-webapps-common, gnome-software
+Conflicts: libreoffice-core, thunderbird, gnome-software, aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support, libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez, gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd, cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell, ubuntu-web-launchers
 Pre-Depends: maratona-essential
 Depends: ssh, maratona-conflitos, maratona-background, maratona-skel, maratona-usuario-icpc, maratona-firewall, maratona-submission, compiz, compizconfig-settings-manager, compiz-plugins-extra, compiz-plugins-main, compiz-plugins
 Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux
@@ -24,11 +24,10 @@ Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux
 
 Package: maratona-conflitos
 Architecture: all
-Conflicts: libreoffice-core, thunderbird, unity-webapps-common, gnome-software
+Conflicts: libreoffice-core, thunderbird, gnome-software, aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support, libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez, gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd, cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell, ubuntu-web-launchers
 Description: Pacote do Maraton Linux com os conflitos para a maratona
  Este pacote além de remover alguns pacotes desnecessários para a maratona
  também desabilita o funcionamento do:
-  - Unity Lenses;
   - Acesso a usuário guest
 
 Package: maratona-virtual-minimal

--- a/debian/maratona-conflitos.postinst
+++ b/debian/maratona-conflitos.postinst
@@ -4,28 +4,29 @@
 dpkg-divert --divert /etc/xdg/update-notifier.desktop-desativado.orig \
             --rename /etc/xdg/autostart/update-notifier.desktop
 
-gsettings set com.canonical.Unity.Lenses disabled-scopes "['more_suggestions-amazon.scope', 'more_suggestions-u1ms.scope', 'more_suggestions-populartracks.scope', 'music-musicstore.scope', 'more_suggestions-ebay.scope', 'more_suggestions-ubuntushop.scope', 'more_suggestions-skimlinks.scope']" >/dev/null 2>&1
-
 if [[ -e /etc/ssh/sshd_config ]] && ! grep -q 'icpc' /etc/ssh/sshd_config; then
   echo "DenyUsers icpc" >> /etc/ssh/sshd_config
 fi
 
 ##TODO deixar isso em arquivos e apenas rodar o dconf update aqui no postinst
 
-mkdir -p /etc/lightdm/lightdm.conf.d
-cat <<EOF > /etc/lightdm/lightdm.conf.d/10-maratona-login-spec.conf
-[Seat:*]
-allow-guest=false
-greeter-hide-users=true
-greeter-show-manual-login=true
+# A pasta db e onde a configuracao e feita de fato
+mkdir -p /etc/dconf/db/gdm.d/
+cat <<EOF > /etc/dconf/db/gdm.d/00-login-screen
+[org/gnome/login-screen]
+# Para nao mostrar a lista de usuarios
+disable-user-list=true
 EOF
 
+# A pasta profile/ diz para quem aplicar e diz aonde achar a o que deve ser feito
 mkdir -p /etc/dconf/{profile,db/local.d}
-cat > /etc/dconf/profile/user <<EOF
+cat > /etc/dconf/profile/gdm <<EOF
 user-db:user
-system-db:local
+system-db:gdm
+file-db:/usr/share/gdm/greeter.dconf-defaults
 EOF
 
+# Desativa as notificacoes
 cat > /etc/dconf/db/local.d/update-manager <<EOF
 [com/ubuntu/update-notifier]
 no-show-notifications=false

--- a/debian/maratona-conflitos.postrm
+++ b/debian/maratona-conflitos.postrm
@@ -3,4 +3,4 @@
 #recolocando o autostart do update-notifier
 dpkg-divert --rename --remove /etc/xdg/autostart/update-notifier.desktop
 
-rm /etc/lightdm/lightdm.conf.d/10-maratona-login-spec.conf
+rm /etc/dconf/db/gdm.d/00-login-screen


### PR DESCRIPTION
O maratona-conflitos elimina os pacotes não necessários ao competidor do
maratona no Ubuntu 18.04. São eles pacotes de e-mail, bluetooth, ferramentas
de escritório (pacote do libreoffice), jogos, torrent e alguns pacotes do
gnome.

debian/maratona-meta.post{inst,rm}: Adaptação do login de usuário,
que antes, nas versões anteriores do Ubuntu utilizava o Lightdm agora
utiliza-se o GDM.

Segue a lista dos pacotes adicionados aos conflitos:
  aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support,
  libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez,
  gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd,
  cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell,
  ubuntu-web-launchers.