### PR TITLE
debian/{control,maratona-editores*}: Atualizando dependêndencias e scripts.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,6 @@ Description: Pacote Virtual com as dependências mínimas para o ambiente marato
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 
-
 Package: maratona-linguagens
 Architecture: all
 Depends: build-essential, default-jre, default-jdk, libstdc++6-4.7-dev, libstdc++6-4.7-dbg, gdb, python3, pyflakes, pyflakes3, python, fpc-3.0.0
@@ -63,7 +62,7 @@ Description: Pacote contendo as dependências de documentação das linguagens
 
 Package: maratona-editores
 Architecture: all
-Depends: vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, eclipse, eclipse-pde, eclipse-rcp, eclipse-platform, eclipse-jdt, eclipse-cdt, emacs, gedit, gedit-plugins, gedit-developer-plugins
+Depends: maratona-linguagens, vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, emacs, gedit, gedit-plugins, gedit-developer-plugins, kate, konsole, codeblocks, netbeans
 Description: Pacote Virtual do Maratona Linux com os editores permitidos
  na maratona
  .

--- a/debian/maratona-editores.postinst
+++ b/debian/maratona-editores.postinst
@@ -1,3 +1,50 @@
 #!/bin/bash
+set -e
+. /usr/share/debconf/confmodule
+# Function which try install a program of Snap in 3 tries.
+# Defaults of requisition:
+#   $1 - Name of package
+#   $2 - Arg1 of snap (--classic or --edge)
+#   $3 - Arg2 of snap (--classic or --edge)
 
-snap install pycharm-community --classic
+try_install_snap() {
+	try=0
+	while [ $(snap list | grep $1 | wc -l) -eq 0 ] && [ $try -lt 3 ]; do
+		snap install $1 $2 $3
+	    try=$((try+1))
+	done
+
+	# In case of success, return 0. In case of failure, return 1.
+	if [ $(snap list | grep $1 | wc -l) -eq 0 ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+flag=1
+while [ $flag -eq 1 ]; do
+	packages=""
+	try_install_snap pycharm-community --classic || packages=$packages"pycharm-community"
+
+	try_install_snap intellij-idea-community --classic --edge || \
+	packages=$packages", intellij-idea-community"
+
+	try_install_snap eclipse --classic || packages=$packages", eclipse"
+
+	if [ "$packages" != "" ]; then
+		db_subst maratona-editores/question_try_again package $packages || true
+		db_input high maratona-editores/question_try_again || true
+		db_go || true
+		db_get maratona-editores/question_try_again || true
+		if [ "$RET" == "Later" ]; then
+			flag=0
+			db_input high maratona-editores/notice || true
+			db_go || true
+			db_get maratona-editores/notice
+		fi
+	else
+		flag=0
+	fi
+done
+

--- a/debian/maratona-editores.templates
+++ b/debian/maratona-editores.templates
@@ -1,0 +1,11 @@
+Template: maratona-editores/question_try_again
+Type: select
+Choices: Try Again, Later
+Description: It's was no possible install the package(s) ${package} via snap.
+ Do you want to try install again, or later?
+
+Template: maratona-editores/notice
+Type: note
+Description: Please, try again another time with:
+ sudo dpkg-reconfigure maratona-editores
+


### PR DESCRIPTION
debian/control: Adicionado o kate, codeblocks e netbeans, como novos editores
para a nova edição do Maratona Linux, o konsole como plugin do kate, e o
maratona-linguagens. Foi removido o eclipse, juntamente com os seus plugins
das dependências devido algum error interno do mesmo, atribuindo como
solução instala-lo via Snap.

debian/maratona-editores.postint: O scripts de pós instalação tem como função
instalar os editores da Jetbrains, o Pycharm Community e o Intellij Idea
Community, e o Eclipse dos repositórios do Snap. Juntamente com a intalação do
mesmo, foi adicionado uma verificação de erro, para casos de falha na
instalação, o usuário ser informado de fazer uma nova tentativa na instalação
dos mesmos ou tentar instalar depois com dpkg-reconfigure maratona-editores.

debian/maratona-editores.template: Adicionado os templates necessários para
perguntar ao usuário, em caso de falhas nas instalações dos programas via snap,
se ele deseja tentar novamente realizar as instalações dos programas ou se
deseja realiza-las em um outro momento.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>