### PR TITLE
debian/{control,maratona-linguagens.*}: Atualizando dependências e scripts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Description: Pacote Virtual com as dependências mínimas para o ambiente marato
 
 Package: maratona-linguagens
 Architecture: all
-Depends: build-essential, default-jre, default-jdk, libstdc++6-4.7-dev, libstdc++6-4.7-dbg, gdb, python3, pyflakes, pyflakes3, python, fpc-3.0.0
+Depends: build-essential, default-jre, default-jdk, libstdc++-7-dev, libstdc++6-7-dbg, gdb, python3, pyflakes, pyflakes3, python
 Description: Pacote com os compiladores das linguagens de programação
  aceitas na maratona
  .

--- a/debian/maratona-linguagens.postinst
+++ b/debian/maratona-linguagens.postinst
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+. /usr/share/debconf/confmodule
+
+try_install_snap(){
+	try=0
+	while [ $(snap list | grep $1 | wc -l) -eq 0 ] && [ $try -lt 3 ]; do
+		snap install $1 $2 $3
+		try=$((try+1))
+	done
+
+	if [ $(snap list | grep $1 | wc -l) -eq 0 ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+flag=1
+while [ $flag -eq 1 ]; do
+	packages=""
+	try_install_snap kotlin --classic || packages=$packages"kotlin"
+
+	if [ "$packages" != "" ]; then
+		db_subst maratona-linguagens/question_try_again package $packages || true
+		db_input high maratona-linguagens/question_try_again || true
+		db_go || true
+		db_get maratona-linguagens/question_try_again || true
+		if [ "$RET" == "Later" ]; then
+			flag=0
+			db_input high maratona-linguagens/notice || true
+			db_go || true
+			db_get maratona-linguagens/notice
+		fi
+	else
+		flag=0
+	fi
+done
+

--- a/debian/maratona-linguagens.templates
+++ b/debian/maratona-linguagens.templates
@@ -1,0 +1,10 @@
+Template: maratona-linguagens/question_try_again
+Type: select
+Choices: Try Again, Later
+Description: It's was no possible install the package(s) ${package} via snap.
+ Do you want to try install again, or later?
+
+Template: maratona-linguagens/notice
+Type: note
+Description: Please, try again another time with:
+	sudo dpkg-reconfigure maratona-editores


### PR DESCRIPTION
debian/control: Atualizado as dependências libstdc++6-4.7-dev para
libstdc++-7-dev e libstdc++6-4-7-dbg para libstdc++6-7-dgb. Removendo o fpc como
dependência.

debian/maratona-linguagens.postinst: Script de instalação para o Kotlin, da
Jetbrains, pelo repositório do Snap. Juntamente com a instalação, foi adicionado
uma verificação de erro, para casos de falha na instalação, o usuário poder
decidir fazer uma nova tentativa na instalação do mesmo ou tentar instalar
depois com dpkg-reconfigure maratona-linguagens.

debian/maratona-linguagens.templates: Adicionado os templates necessários para
perguntar ao usuário, em caso de falhas nas instalações dos programas via
snap, se ele deseja tentar novamente fazer a instalação do programa ou se deseja
fazer outra hora.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>