### PR TITLE
debian/{control, rules}: Atualizando dependências do maratona-linguagens-doc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Description: Pacote com os compiladores das linguagens de programação
 
 Package: maratona-linguagens-doc
 Architecture: all
-Depends: manpages-dev, gcc-doc, stl-manual, c++-annotations, libstdc++6-4.7-doc, default-jdk-doc, python3-doc, python2.7-doc, fp-docs-3.0.0, cppreference-doc-en-html
+Depends: manpages-dev, gcc-doc, libstdc++-7-doc, default-jdk-doc, python3-doc, python2.7-doc, cppreference-doc-en-html
 Description: Pacote contendo as dependências de documentação das linguagens
  aceitas na maratona
  .

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,10 @@
 #! /usr/bin/make -f
 
 override_dh_auto_install:
+	# Criando atalhos do maratona-linguagens-doc em /usr/share/applications
+	mkdir -p debian/maratona-linguagens-doc/usr/share/applications/
+	cp icones-desktop/* debian/maratona-linguagens-doc/usr/share/applications/
+
 	mkdir -p debian/maratona-skel/etc/skel/Desktop/
 	cp icones-desktop/* debian/maratona-skel/etc/skel/Desktop/
 	#tar xf mozilla.tar.xz -C debian/maratona-skel/

--- a/icones-desktop/cppannotations.desktop
+++ b/icones-desktop/cppannotations.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1
-Name=C++ Annotations
-Comment=C++ Annotations
-Exec=firefox /usr/share/doc/c++-annotations/html/index.html
-Terminal=false
-Type=Application

--- a/icones-desktop/javadoc.desktop
+++ b/icones-desktop/javadoc.desktop
@@ -2,6 +2,6 @@
 Version=1
 Name=Java API
 Comment=Java API
-Exec=firefox /usr/share/doc/openjdk-8-jre-headless/api/index.html
+Exec=firefox /usr/share/doc/openjdk-11-jre-headless/api/index.html
 Terminal=false
 Type=Application

--- a/icones-desktop/python3doc.desktop
+++ b/icones-desktop/python3doc.desktop
@@ -2,6 +2,6 @@
 Version=1
 Name=Python 3.5 Doc
 Comment=Python Doc
-Exec=firefox /usr/share/doc/python3.5/html/index.html
+Exec=firefox /usr/share/doc/python3.6/html/index.html
 Terminal=false
 Type=Application

--- a/icones-desktop/stldoc.desktop
+++ b/icones-desktop/stldoc.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Version=1
-Name=C++ STL
-Comment=C++ STL
-Exec=firefox /usr/share/doc/stl-manual/html/index.html
-Terminal=false
-Type=Application


### PR DESCRIPTION
debian/control: Atualizando a libstdc++6-4.7-doc para libstdc++-7-doc e
removendo das dependência o c++-annotations, stl-manual e o fpc-docs-3.0.0.

debian/rules: Agora o maratona-linguagens-doc cria atalhos no
/usr/share/applications.

icones-desktop/: Removido os atalhos cppannotations.desktop e stldoc.desktop.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>