### PR TITLE
debian/{control,maratona-skel*,rules}: Removendo maratona-skel do maratona-meta

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,9 +12,9 @@ Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux para máqu
 
 Package: maratona-desktop
 Architecture: all
-Conflicts: libreoffice-core, thunderbird, gnome-software, aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support, libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez, gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd, cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell, ubuntu-web-launchers
+Conflicts: maratona-skel, libreoffice-core, thunderbird, gnome-software, aisleriot, gnome-mahjongg, gnome-mines, gnome-sudoku, libgnome-games-support, libgnome-games-support-common, rhythmbox, nautilus-sendto, bluez, gnome-bluetooth, pulseaudio-module-bluetooth, bluez-cups, bluez-obexd, cheese, cups, mythes-en-us, uno-libs3, transmission-gtk, shotwell, ubuntu-web-launchers
 Pre-Depends: maratona-essential
-Depends: ssh, maratona-conflitos, maratona-background, maratona-skel, maratona-usuario-icpc, maratona-firewall, maratona-submission, compiz, compizconfig-settings-manager, compiz-plugins-extra, compiz-plugins-main, compiz-plugins
+Depends: ssh, maratona-conflitos, maratona-background, maratona-usuario-icpc, maratona-firewall, maratona-submission, compiz, compizconfig-settings-manager, compiz-plugins-extra, compiz-plugins-main, compiz-plugins
 Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux
  Este pacote detém todas as dependências obrigatórias para transformar o
  ubuntu em uma versão controlada do ambiente da maratona.
@@ -68,23 +68,9 @@ Description: Pacote Virtual do Maratona Linux com os editores permitidos
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 
-Package: maratona-skel
-Pre-Depends: maratona-editores, maratona-linguagens-doc
-Depends: coreutils
-Architecture: all
-Description: Pacote que gera o skel personalizado para usuários Maratona Linux
- Neste pacote são gerados os ícones padrões no desktop dos usuários que
- serão adicionados. Os ícones gerados são:
-    - Javadoc
-    - stldoc
-    - cppannotations
-    - eclipse
-    - gedit
-    - emacs
-    - gnome-terminal
-
 Package: maratona-usuario-icpc
-Pre-Depends: maratona-skel, makepasswd
+Pre-Depends: makepasswd
+Conflicts: maratona-skel
 Architecture: all
 Description: Pacote que cria um usuário icpc para o competidor da maratona
  Este pacote cria o usuário sem privilégios administrativos para competição.

--- a/debian/maratona-skel.postinst
+++ b/debian/maratona-skel.postinst
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-[ -f /usr/share/applications/eclipse.desktop ] && cp /usr/share/applications/eclipse.desktop /etc/skel/Desktop/
-[ -f /usr/share/applications/gedit.desktop ] && cp /usr/share/applications/gedit.desktop /etc/skel/Desktop/
-[ -f /usr/share/applications/geany.desktop ] && cp /usr/share/applications/geany.desktop /etc/skel/Desktop/
-[ -f /usr/share/applications/emacs23.desktop ] && cp /usr/share/applications/emacs23.desktop /etc/skel/Desktop/
-[ -f /usr/share/applications/emacs24.desktop ] && cp /usr/share/applications/emacs24.desktop /etc/skel/Desktop/
-cp /usr/share/applications/gnome-terminal.desktop /etc/skel/Desktop/
-chmod 755 /etc/skel/Desktop/*.desktop

--- a/debian/rules
+++ b/debian/rules
@@ -5,11 +5,6 @@ override_dh_auto_install:
 	mkdir -p debian/maratona-linguagens-doc/usr/share/applications/
 	cp icones-desktop/* debian/maratona-linguagens-doc/usr/share/applications/
 
-	mkdir -p debian/maratona-skel/etc/skel/Desktop/
-	cp icones-desktop/* debian/maratona-skel/etc/skel/Desktop/
-	#tar xf mozilla.tar.xz -C debian/maratona-skel/
-	mkdir -p debian/maratona-skel/etc/skel/.local/share/applications/
-	cp firefox.desktop debian/maratona-skel/etc/skel/.local/share/applications/
 	mkdir -p debian/maratona-usuario-icpc/usr/sbin/
 	cp scripts-administrativos/zera-home-icpc debian/maratona-usuario-icpc/usr/sbin/
 	chmod a+x debian/maratona-usuario-icpc/usr/sbin/zera-home-icpc


### PR DESCRIPTION
debian/control: Todos os pacotes que antes tinha como dependência o
maratona-skel, passam conflitar com ele.

maratona-skel não é mais necessário para o maratona-linux, pois sua função será
agora exercida pelo o maratona-desktop.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>