### PR TITLE
debian/{control, maratona-usuario-icpc*}: Atualizando dependências e scripts.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Description: Pacote Virtual do Maratona Linux com os editores permitidos
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 
 Package: maratona-usuario-icpc
-Pre-Depends: makepasswd
+Pre-Depends: maratona-linguagens-doc, makepasswd
 Conflicts: maratona-skel
 Architecture: all
 Description: Pacote que cria um usuário icpc para o competidor da maratona

--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -25,3 +25,21 @@ if ! grep -q zera-home-icpc /etc/rc.local | grep true; then
     sed -i '/^exit 0/i \
 bash \/usr\/sbin\/zera-home-icpc || true' /etc/rc.local
 fi
+
+# Copia os atalhos para area de trabalho.
+mkdir -p /home/icpc/Desktop/
+[ -f /usr/share/applications/cppreference.desktop ] && \
+cp /usr/share/applications/cppreference.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/javadoc.desktop ] && \
+cp /usr/share/applications/javadoc.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/python2doc.desktop ] && \
+cp /usr/share/applications/python2doc.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/python3doc.desktop ] && \
+cp /usr/share/applications/python3doc.desktop /home/icpc/Desktop/
+
+# Muda o dono da pasta de root para icpc
+chmod 755 /home/icpc/Desktop/*
+chown -R icpc:users /home/icpc/Desktop/

--- a/scripts-administrativos/zera-home-icpc
+++ b/scripts-administrativos/zera-home-icpc
@@ -35,6 +35,25 @@ pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 usermod -d /home/icpc -p "$pass" -s /bin/bash -g users icpc
 echo "."
 
+# Copiando os atalhos da documentação para o o Desktop
+mkdir -p /home/icpc/Desktop/
+[ -f /usr/share/applications/cppreference.desktop ] && \
+cp /usr/share/applications/cppreference.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/javadoc.desktop ] && \
+cp /usr/share/applications/javadoc.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/python2doc.desktop ] && \
+cp /usr/share/applications/python2doc.desktop /home/icpc/Desktop/
+
+[ -f /usr/share/applications/python3doc.desktop ] && \
+cp /usr/share/applications/python3doc.desktop /home/icpc/Desktop/
+
+# Mudando o dono, pois este script roda como root, então o que ele cria
+# pertence ao root, o que não deve acontecer.
+chown -R icpc:users /home/icpc/Desktop/
+chmod 755 /home/icpc/Desktop/*
+
 for i in media mnt var opt tmp usr; do
   printf "Removing files from: /$i"
   find /$i -user icpc -delete


### PR DESCRIPTION
debian/control: Agora o maratona-usuario-icpc copia os atalhos do
maratona-linguagens-doc para a área de trabalho. Então, por consequência, agora
o maratona-usuario-icpc pré-depende do maratona-linguagens-doc.

debian/maratona-usuario-icpc.postinst: Agora este script copia os atalhos
referentes do maratona-linguagens-doc para a área de trabalho.

scripts-administrativos/zera-home-icpc: Agora este script copia os atalhos
referentes do maratona-linguagens-doc para a área de trabalho para garantir
que quando a home do usuário for zerada, os atalhos das documentações
estejam no seu devido lugar.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>