### PR TITLE
debian/{control,rules,maratona-desktop*}: Atualização de conflitos e scripts.

### DIFF
--- a/debian/maratona-desktop.postinst
+++ b/debian/maratona-desktop.postinst
@@ -1,5 +1,17 @@
 #!/bin/bash
+set -e
 
-#Force UTC timezone
-cp /usr/share/zoneinfo/UCT /etc/localtime || true
-cp /usr/share/zoneinfo/UCT /etc/timezone || true
+# Faz uma nova entrada no dconf para adicionar os atalhos favoritos
+mkdir -p /etc/dconf/profile/
+cat << EOF > /etc/dconf/profile/user
+user-db:user
+system-db:local
+EOF
+
+mkdir -p /etc/dconf/db/local.d
+cat << EOF > /etc/dconf/db/local.d/favoritos
+[org/gnome/shell]
+favorite-apps = ['firefox_boca.desktop', 'eclipse_eclipse.desktop', 'gedit.desktop', 'geany.desktop', 'emacs25.desktop', 'org.kde.kate.desktop', 'codeblocks.desktop', 'gnome-terminal.desktop', 'pycharm-community_pycharm-community.desktop', 'intellij-idea-community_intellij-idea-community.desktop', 'netbeans.desktop']
+EOF
+
+dconf update

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,10 @@ override_dh_auto_install:
 	mkdir -p debian/maratona-linguagens-doc/usr/share/applications/
 	cp icones-desktop/* debian/maratona-linguagens-doc/usr/share/applications/
 
+	# Firefox copiado e renomeado
+	mkdir -p debian/maratona-desktop/usr/share/applications/
+	cp firefox.desktop debian/maratona-desktop/usr/share/applications/firefox_boca.desktop
+
 	mkdir -p debian/maratona-usuario-icpc/usr/sbin/
 	cp scripts-administrativos/zera-home-icpc debian/maratona-usuario-icpc/usr/sbin/
 	chmod a+x debian/maratona-usuario-icpc/usr/sbin/zera-home-icpc


### PR DESCRIPTION
debian/maratona-desktop.postinst: Script que tem como função inserir os editores
utilizados pelo usuário do maratona na barra de favoritos. Os atalhos que foram
inseridos são: firefox_boca, eclipse, gedit, geany, emacs25, kate,
codeblocks, gnome-terminal, pycharm-community, intellij-idea-community e
netbeans.

debian/rules: O icone do firefox é copiado para /usr/share/applications/
com o nome de firefox_boca, este atalho faz com que o firefox abra na página
do BOCA.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>