### PR TITLE
debian/maratona-usuario-icpc.postinst: Tirada mensagem de primeiro acesso do Gnome

### DIFF
--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Antes de criar o usuario, criar no skel um arquivo para nunca aparecer
+# a mensagem inicial do gnome. Só é preciso fazer uma vez, pois quando
+# o script do zera home é executado, é restaurado o skel dele
+mkdir -p /etc/skel/.config/
+cat << EOF > /etc/skel/.config/gnome-initial-setup-done
+yes
+EOF
+
 pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 id -u icpc >/dev/null 2>/dev/null
 if [ $? != 0 ]; then


### PR DESCRIPTION
debian/maratona-usuario-icpc.postinst: No script de postinst do
maratona-usuario-icpc foi removido a mensagem de primeiro acesso do gnome. Pois
como será feita uma constante limpeza na home do usuário icpc, para não aparecer a
mensagem de primeiro acesso foi preciso colocar um arquivo chamado
gnome-initial-setup-done dentro da pasta /etc/skel/.config/.
Esse arquivo é o mesmo que é criado pelo o gnome quando a mensagem
aparece no primeiro acesso do usuário, então a solução é simular
que a mensagem já apareceu criando o arquivo.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>