### PR TITLE
maratona-usuario-icpc: zera-home-icpc agora é executado ao inicializar o sistema.

### DIFF
--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -26,14 +26,6 @@ if ! grep -q "^icpc " /etc/security/limits.conf; then
   echo "icpc          hard nproc 1024" >> /etc/security/limits.conf
 fi
 
-grep -v 'zera-home-icpc' /etc/rc.local > /tmp/t
-mv /tmp/t /etc/rc.local
-chmod a+x /etc/rc.local
-if ! grep -q zera-home-icpc /etc/rc.local | grep true; then
-    sed -i '/^exit 0/i \
-bash \/usr\/sbin\/zera-home-icpc || true' /etc/rc.local
-fi
-
 # Copia os atalhos para area de trabalho.
 mkdir -p /home/icpc/Desktop/
 [ -f /usr/share/applications/cppreference.desktop ] && \
@@ -51,3 +43,6 @@ cp /usr/share/applications/python3doc.desktop /home/icpc/Desktop/
 # Muda o dono da pasta de root para icpc
 chmod 755 /home/icpc/Desktop/*
 chown -R icpc:users /home/icpc/Desktop/
+
+# Adiciona o "servico" do zera-home-icpc para executar na inicializacao
+systemctl enable maratona-usuario-icpc.service

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,10 @@ override_dh_auto_install:
 	mkdir -p debian/maratona-desktop/usr/share/applications/
 	cp firefox.desktop debian/maratona-desktop/usr/share/applications/firefox_boca.desktop
 
+	# Service para zerar home no reboot via systemd
+	mkdir -p debian/maratona-usuario-icpc/lib/systemd/system/
+	cp usuario-icpc-service/maratona-usuario-icpc.service debian/maratona-usuario-icpc/lib/systemd/system/
+
 	mkdir -p debian/maratona-usuario-icpc/usr/sbin/
 	cp scripts-administrativos/zera-home-icpc debian/maratona-usuario-icpc/usr/sbin/
 	chmod a+x debian/maratona-usuario-icpc/usr/sbin/zera-home-icpc

--- a/usuario-icpc-service/maratona-usuario-icpc.service
+++ b/usuario-icpc-service/maratona-usuario-icpc.service
@@ -1,0 +1,16 @@
+
+# "Deamon" do maratona-usuario-icpc para ser executado na
+# inicialização da maquina verificando se deve ser feito a limpeza
+# da home do usuario icpc.
+
+[Unit]
+Description=Maratona Zera Home ICPC Deamon
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/sbin/zera-home-icpc
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
debian/rules: Foi adicionado no pacote do maratona-usuario-icpc um arquivo
.service que é reconhecido pelo systemd. Este arquivo possui o nome de
maratona-usuario-icpc.service, na qual esse arquivo fica na pasta
/lib/systemd/system/.

usuario-icpc-service/maratona-usuario-icpc.service: Arquivo nos padrões do
systemd que executa o script zera-home-icpc ao inicializar o sistema. Esse
script sempre falha caso não existir o arquivo criado pelo o
clean-icpc-on-reboot, caso contrario, ele é executado com sucesso. Removido
trecho do Script que fazia essa função pelo /etc/rc.local

debian/maratona-usuario-icpc.postinst: No script de postinst o serviço é
habilitado pelo systemctl.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>