### PR TITLE
maratona-editores: Correção de bugs.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,7 +62,7 @@ Description: Pacote contendo as dependências de documentação das linguagens
 
 Package: maratona-editores
 Architecture: all
-Depends: maratona-linguagens, vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, emacs, gedit, gedit-plugins, gedit-developer-plugins, kate, konsole, codeblocks, netbeans
+Depends: maratona-linguagens, vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, emacs, gedit, gedit-plugins, gedit-developer-plugins, kate, konsole, codeblocks, netbeans, python3-distutils, python-distutils-extra
 Description: Pacote Virtual do Maratona Linux com os editores permitidos
  na maratona
  .


### PR DESCRIPTION
debian/control: Adicionado como dependencia ao maratona-editores o
python3-distutils e python-distutils-extra como correção da mensagem de erro
gerada pelo Pycharm na primeira inicializao de projeto, no qual reclamava  da falta 
do python-distutils. Portanto, instalando esse pacote juntamente com o 
maratona-editores, resolve o problema.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>