### PR TITLE
maratona-desktop: Adicionado script que altera metadado do icones .de…

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,11 @@ override_dh_auto_install:
 	mkdir -p debian/maratona-desktop/usr/share/applications/
 	cp firefox.desktop debian/maratona-desktop/usr/share/applications/firefox_boca.desktop
 
+	# Script para ser inicializado no começo da secao para marcar os atalhos
+	# como confiaveis
+	mkdir -p debian/maratona-desktop/etc/profile.d/
+	cp maratona-profile/maratona-desktop-profile.sh debian/maratona-desktop/etc/profile.d/
+
 	# Service para zerar home no reboot via systemd
 	mkdir -p debian/maratona-usuario-icpc/lib/systemd/system/
 	cp usuario-icpc-service/maratona-usuario-icpc.service debian/maratona-usuario-icpc/lib/systemd/system/

--- a/maratona-profile/maratona-desktop-profile.sh
+++ b/maratona-profile/maratona-desktop-profile.sh
@@ -1,0 +1,10 @@
+# Percorre todos os arquivos.desktop na home do usuario de deixa
+# Os arquivos confiaveis
+if [ ! -f "$HOME/.config/desktop-trusted" ] ; then
+	for x in $HOME/Desktop/*.desktop ; do
+		[ -f $x ] && gio set $x "metadata::trusted" yes
+	done
+
+	echo "yes" > $HOME/.config/desktop-trusted
+
+fi


### PR DESCRIPTION
…sktop.

maratona-profile/maratona-desktop-profile.sh: Adicionado um script que é
executado ao iniciar a secção de usuário. Esse script possui como objetivo
colocar os .desktop da área de trabalho (criado pelo maratona-usuario-icpc) como
confiavéis. Portanto, como solução, é adicionar esse script em /etc/profile.d/
no qual possui scripts que é executado ao inicializar a secção de usuário.
Dentro do script é dado um "gio set <icon.desktop> "metadata::trusted" yes",
assim, ao inicializar a secção, os icones da área de trabalho ficam com os
icones verdadeiros, descritos no seu .desktop, sem precisar marcar o icone como confiavel.

debian/rules: O Script acima tem como nome maratona-desktop-profile.sh e é
copiado para /etc/profile.d.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>