### PR TITLE
maratona-editores: Removido o netbeans como dependência.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,7 @@ Description: Pacote contendo as dependências de documentação das linguagens
 Package: maratona-editores
 Pre-Depends: maratona-linguagens
 Architecture: all
-Depends: maratona-linguagens, vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, emacs, gedit, gedit-plugins, gedit-developer-plugins, kate, konsole, codeblocks, netbeans, python3-distutils, python-distutils-extra
+Depends: maratona-linguagens, vim, vim-gnome, geany, geany-plugins, geany-plugin-addons, emacs, gedit, gedit-plugins, gedit-developer-plugins, kate, konsole, codeblocks, python3-distutils, python-distutils-extra
 Description: Pacote Virtual do Maratona Linux com os editores permitidos
  na maratona
  .


### PR DESCRIPTION
debian/control: Netbeans removido como dependência do maratona-editores por
causa de incompatibilidade com a versão do openjdk-default

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>