### PR TITLE
maratona-{editores,usuario-icpc}: Adicionado arquivo de configuração dos editores

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,10 @@ override_dh_auto_install:
 	mkdir -p debian/maratona-desktop/etc/profile.d/
 	cp maratona-profile/maratona-desktop-profile.sh debian/maratona-desktop/etc/profile.d/
 
+	# Arquivo de configuração dos editores
+	mkdir -p debian/maratona-editores/etc/skel/
+	cp maratona-editores-config/* debian/maratona-editores/etc/skel/
+
 	# Service para zerar home no reboot via systemd
 	mkdir -p debian/maratona-usuario-icpc/lib/systemd/system/
 	cp usuario-icpc-service/maratona-usuario-icpc.service debian/maratona-usuario-icpc/lib/systemd/system/

--- a/scripts-administrativos/zera-home-icpc
+++ b/scripts-administrativos/zera-home-icpc
@@ -35,6 +35,16 @@ pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 usermod -d /home/icpc -p "$pass" -s /bin/bash -g users icpc
 echo "."
 
+# Os arquivos de configuração dos editores do maratona estão no arquivo
+# maratona-desktop-configs.tar.gz que são mantidos no skel e quando o usuario
+# icpc é recriado, é copiado para a home do icpc, extraido e excluido (o
+# .tar.gz)
+[ -f /home/icpc/maratona-desktop-configs.tar.xz ] && \
+tar -xf /home/icpc/maratona-desktop-configs.tar.xz -C /home/icpc/ && \
+rm /home/icpc/maratona-desktop-configs.tar.xz
+
+chown -R icpc:users ~icpc
+
 # Copiando os atalhos da documentação para o o Desktop
 mkdir -p /home/icpc/Desktop/
 [ -f /usr/share/applications/cppreference.desktop ] && \


### PR DESCRIPTION
debian/rules: Adicionando em /etc/skel o arquivo
maratona-desktop-configs.tar.xz com objetivo de copiar todas as configurações
dos editores da jetbrains que possui como primeira tela, um termo de aceite, que
não pode ser exibido para o usuário. O arquivo é embarcado dentro do pacote do
maratona-editores.

scripts-administrativos/zera-home-icpc: Adicionado um trecho do script no qual o
arquivo maratona-dekstop-configs.tar.xz que foi copiado para home do usuário
icpc é extraído e excluído, a fim de que o usuário não tenha consigo esse
arquivo em sua home.

maratona-editores-config/maratona-desktop-configs.tar.xz: Arquivo com todas as
configurações iniciais necessárias dos programas da jetbrains e do eclipse. Com
esses arquivos na home do usuário, no primeiro acesso apos zerar a home do
usuário, não aparece as mensagens iniciais, como os termos de compromisso e de
escolha de configuração.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>