### PR TITLE
maratona-usuario-icpc: Senha invalida para o primeiro acesso do usuário icpc.

### DIFF
--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -8,7 +8,7 @@ cat << EOF > /etc/skel/.config/gnome-initial-setup-done
 yes
 EOF
 
-pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
+pass=$(echo -n icpcd | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 id -u icpc >/dev/null 2>/dev/null
 if [ $? != 0 ]; then
   useradd -d /home/icpc -k /etc/skel -m -p "$pass" -s /bin/bash -g users icpc


### PR DESCRIPTION
debian/maratona-usuario-icpc.postinst: Senha mudada para "icpcd" a fim de forçar
o usuário reiniciar a máquina após a instalação do usuário icpc. Esse
procedimento é realizado a fim de que os scripts de restauração do usuario icpc
é feito juntamente com o boot do sistema. Quando o usuário é restaurado, é restaurado 
também a senha do usuário como "icpc".

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>