### PR TITLE
maratona-usuario-icpc: Atualizado scripts de adição de usuario icpc.

### DIFF
--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -8,27 +8,26 @@ cat << EOF > /etc/skel/.config/gnome-initial-setup-done
 yes
 EOF
 
-pass=$(echo -n icpcd | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 id -u icpc >/dev/null 2>/dev/null
-if [ $? != 0 ]; then
-  useradd -d /home/icpc -k /etc/skel -m -p "$pass" -s /bin/bash -g users icpc
-else
+if [ $? == 0 ]; then
+  # Se o usuario existe, vai verificar os previlegios dele.
+  # Se for root, vai abortar a instalação, caso contrario, irá mudar o grupo de
+  # usuario dele.
   if getent group sudo|grep -q "\<icpc\>"; then
     echo "Ops. Usuário ICPC com privilégios administrativos. ABORTANDO"
     echo "   Remova o usuário ICPC do grupo sudo"
     exit 1
   fi
+  pass=$(echo -n icpcd | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
   usermod -d /home/icpc -p "$pass" -s /bin/bash -g users icpc
   echo "user icpc already exists"
 fi
 
-if ! grep -q "^icpc " /etc/security/limits.conf; then
-  echo "icpc          hard nproc 1024" >> /etc/security/limits.conf
-fi
-
-# Adiciona o "servico" do zera-home-icpc para executar na inicializacao
+# Adiciona o "servico" do zera-home-icpc para executar na inicializao
 systemctl enable maratona-usuario-icpc.service
 
 # Colocando para o usuario icpc ter sua home zerada no boot criando o arquivo
 # .clean-home que faz o servico do usuario icpc ser executado
+mkdir -p /home/icpc/
 touch /home/icpc/.clean-home
+

--- a/scripts-administrativos/zera-home-icpc
+++ b/scripts-administrativos/zera-home-icpc
@@ -8,30 +8,44 @@ if ! whoami|grep -q root; then
   exit 1
 fi
 
-if [[ ! -e "/home/icpc/.clean-home" ]] && [[ "$1" != "-f" ]]; then
+# Se o usuario icpc não existe, o script deve passar adiante para cria-lo.
+# No caso de uma nova instalação via LiveCD do maratona na máquina, o usuario
+# não existe, e nesse caso, ele deve ser criado para que o ambiente já esteja
+# pronto para uso. No caso de uma instação via apt, o .clean-home irá existir no
+# diretorio, e o usuario não vai existir, o que deve cria-lo.
+getent passwd icpc &>/dev/null
+RESP="$?"
+if [[ ! -e "/home/icpc/.clean-home" ]] && [[ "$1" != "-f" ]] && ((RESP == 0)) ; then
   echo "No /home/icpc/.clean-home file found"
   echo "If you wish to clean anyway run:"
   echo "  $0 -f"
   exit 1
 fi
 
-printf "Verificando existência do usuário \"icpc\""
-getent passwd icpc &>/dev/null
-RESP="$?"
-if ((RESP != 0 )); then
-  echo ". falhou"
-  echo "abortando".
-  exit 1
-fi
-echo "."
+# Gera uma senha de inicio.
+pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
 
+# Verifica a existencia do usuario ICPC
+# Caso ele não exista, ele deve ser criado com a senha criada anteriormente.
+printf "Verificando existência do usuário \"icpc\""
+if ((RESP != 0 )); then
+	echo "."
+	echo "Usuario não exite, criando..".
+	useradd -d /home/icpc -k /etc/skel -m -p "$pass" -s /bin/bash -g users icpc
+
+	if ! grep -q "^icpc " /etc/security/limits.conf; then
+		echo "icpc          hard nproc 1024" >> /etc/security/limits.conf
+	fi
+fi
+
+# De qualquer modo, o seu diretorio tem que ser recriado.
 printf "Recriando diretório home"
 rm -rf ~icpc
 cp -a /etc/skel ~icpc
 chown -R icpc:users ~icpc
 echo "."
 printf "Restaurando senha"
-pass=$(echo -n icpc | makepasswd --clearfrom - --crypt-md5 | awk '{print $NF}')
+# E o usermod será pra todos.
 usermod -d /home/icpc -p "$pass" -s /bin/bash -g users icpc
 echo "."
 


### PR DESCRIPTION
debian/maratona-usuario-icpc.postinst: Agora é responsabilidade do script
zera-home-icpc criar o usuário icpc caso ele não existir. Isso facilita quando o
maratona-linux for distruido em imagens onde o usuário icpc não é criado por
padrão. O postinst do maratona-usuario-icpc ele é responsavél por verificar se
existe um usuario icpc na máquina, caso o usuário icpc existir e possuir privilégio de
superusuário, o script é encerrado com retorno de erro. Caso não possuir
privilégio de superusuário, a sua conta de usuário é alterada no sistema.

scripts-administrativos/zera-home-icpc: Agora é responsabilidade desse script
criar o usuário icpc caso ele não exista na máquina. Isso será util quando
estiver disponível a imagem do sistema do maratona-linux. Quando é verificado
que o usuário não existe, ao invés de sair do script (como é feito na versão
anterior), ele cria o novo usuário.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>