### PR TITLE
maratona-profile/maratona-desktop-profile.sh: Tirando verificação de arquivo.

### DIFF
--- a/maratona-profile/maratona-desktop-profile.sh
+++ b/maratona-profile/maratona-desktop-profile.sh
@@ -1,10 +1,10 @@
 # Percorre todos os arquivos.desktop na home do usuario de deixa
 # Os arquivos confiaveis
-if [ ! -f "$HOME/.config/desktop-trusted" ] ; then
-	for x in $HOME/Desktop/*.desktop ; do
-		[ -f $x ] && gio set $x "metadata::trusted" yes
-	done
+#if [ ! -f "$HOME/.config/desktop-trusted" ] ; then
 
-	echo "yes" > $HOME/.config/desktop-trusted
+for x in $HOME/Desktop/*.desktop ; do
+	[ -f $x ] && gio set $x "metadata::trusted" yes
+done
 
-fi
+#echo "yes" > $HOME/.config/desktop-trusted
+#fi


### PR DESCRIPTION
Tirando verificação se o arquivo desktop-trusted foi criado na pasta
~/.config/ para que o script funcione com sucesso na imagem que
sera gerada do maratona-linux. Como é um script que executa para poucos
arquivos, somente os atalhos na área de trabalho, sua execução tem pouca
influência na inicialização da sessão de usuário.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>