### PR TITLE
maratona-{desktop,editores,linguagens*,usuario*}: Adicionado script postrm.

### DIFF
--- a/debian/maratona-desktop.postrm
+++ b/debian/maratona-desktop.postrm
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# Removendo o icone do firefox_boca.desktop dos atalhos
+[ -f /usr/share/applications/firefox_boca.desktop ] && \
+  rm /usr/share/applications/firefox_boca.desktop
+
+# Removendo o profile - Script para alterar o metadado dos icones na area de
+# trabalho
+[ -f /etc/profile.d/maratona-desktop-profile.sh ] && \
+  rm /etc/profile.d/maratona-desktop-profile.sh
+
+# Removendo os profiles do dconf - barra de favoritos
+[ -f /etc/dconf/profile/user ] && \
+  rm /etc/dconf/profile/user
+
+[ -f /etc/dconf/db/local.d/favoritos ] && \
+  rm /etc/dconf/db/local.d/favoritos
+
+dconf update

--- a/debian/maratona-editores.postrm
+++ b/debian/maratona-editores.postrm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Removendo os pacotes instalados via snap e removendo os arquivos de
+# configuracao
+snap remove pycharm-community
+snap remove intellij-idea-community
+snap remove eclipse
+
+[ -f /etc/skel/maratona-desktop-configs.tar.xz ] && \
+	rm /etc/skel/maratona-desktop-configs.tar.xz

--- a/debian/maratona-linguagens-doc.postrm
+++ b/debian/maratona-linguagens-doc.postrm
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Removendo os icones criados.
+[ -d /usr/share/icons/maratona-linguagens-doc/ ] && \
+rm -r /usr/share/icons/maratona-linguagens-doc/
+
+# Removendo os atalhos criados em /usr/share/applications/
+[ -f /usr/share/applications/cppreference.desktop ] && \
+  rm /usr/share/applications/cppreference.desktop
+
+[ -f /usr/share/applications/javadoc.desktop ] && \
+  rm /usr/share/applications/javadoc.desktop
+
+[ -f /usr/share/applications/python2doc.desktop ] && \
+  rm /usr/share/applications/python2doc.desktop
+
+[ -f /usr/share/applications/python3doc.desktop ] && \
+  rm /usr/share/applications/python3doc.desktop

--- a/debian/maratona-linguagens.postrm
+++ b/debian/maratona-linguagens.postrm
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# Removendo o kotlin, adicionado com a instalação via snap
+snap remove kotlin

--- a/debian/maratona-usuario-icpc.postrm
+++ b/debian/maratona-usuario-icpc.postrm
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Removendo os scripts utilizados pelo usuario icpc e seus serviços associados.
+
+systemctl disable maratona-usuario-icpc.service
+
+[ -f /lib/systemd/system/maratona-usuario-icpc.service ] && \
+	rm /lib/systemd/system/maratona-usuario-icpc.service
+
+[ -f /usr/sbin/zera-home-icpc ] && \
+	rm /usr/sbin/zera-home-icpc
+
+[ -f /usr/bin/clean-icpc-on-reboot ] && \
+	rm /usr/bin/clean-icpc-on-reboot


### PR DESCRIPTION
debian/maratona-desktop.postrm: Removendo do sistema todos os arquivos referentes
ao maratona-desktop, são eles: atalhos da barra de favoritos, perfils de usuários
do dconf e script do profile.d.

debian/maratona-editores.postrm: Removendo os editores instalados via snap
(pycharm, intellij-idea e eclipse) e removendo o arquivo de configuração criado
para eles.

debian/maratona-linguagens-doc.postrm: Removendo os atalhos de documentação.

debian/maratona-linguagens.postrm: Removendo o compilador de kotlin, que foi
instalado via snap.

debian/maratona-usuario-icpc.postrm: Desativando o serviço
maratona-usuario-icpc.service e removendo o arquivo que descreve esse serviço em
/lib/systemd/system/maratona-usuario-icpc.service. Também são removidos os
scripts zera-home-icpc e o clean-icpc-on-reboot.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>