### PR TITLE
Change accessibility and initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ debian/maratona-desktop-latam/
 debian/maratona-desktop/
 debian/maratona-essential/
 debian/maratona-usuario-icpc/
+debian/maratona-flatpak-common/
+debian/maratona-task-data/

--- a/dconf/40-accessibility
+++ b/dconf/40-accessibility
@@ -1,0 +1,2 @@
+[org/gnome/desktop/a11y]
+always-show-universal-access-status=true

--- a/scripts-administrativos/zera-home-icpc
+++ b/scripts-administrativos/zera-home-icpc
@@ -88,6 +88,8 @@ su icpc -c 'dbus-launch gio set /home/icpc/Desktop/python3doc.desktop "metadata:
 cp /usr/share/applications/kotlindoc.desktop /home/icpc/Desktop/ && \
 su icpc -c 'dbus-launch gio set /home/icpc/Desktop/kotlindoc.desktop "metadata::trusted" true'
 
+# Bloquear a execução do diálogo de boas vindas no primeiro login do usuário
+echo "yes" > /home/icpc/.config/gnome-initial-setup-done
 
 # Mudando o dono, pois este script roda como root, então o que ele cria
 # pertence ao root, o que não deve acontecer.


### PR DESCRIPTION
The `.gitignore` was updated in order to keep all build artifacts
ignore by Git. Also, the default configuration for new users has
changed in order to enable the accessibility menu and remove Ubuntu's
initial setup dialogue.

- adds build artifacts from `maratona-flatpak` common and
`maratona-task-data` to `.gitignore`
- enables the display of the accessibility menu by default
- removes the initial setup dialogue shown to new users on Ubuntu 20.04