### PR TITLE
Release version 20210517.1

### DIFF
--- a/dconf/50-favorites
+++ b/dconf/50-favorites
@@ -1,2 +1,2 @@
 [org/gnome/shell]
-favorite-apps = ['firefox_boca.desktop', 'nautilus.desktop', 'gnome-terminal.desktop', 'com.jetbrains.CLion.desktop', 'com.jetbrains.IntelliJ-IDEA-Community.desktop', 'com.jetbrains.PyCharm-Community.desktop', 'gedit.desktop', 'codeblocks.desktop', 'com.visualstudio.code.desktop', 'org.eclipse.Java.desktop']
+favorite-apps = ['firefox_boca.desktop', 'nautilus.desktop', 'gnome-terminal.desktop', 'com.jetbrains.CLion.desktop', 'com.jetbrains.IntelliJ-IDEA-Community.desktop', 'com.jetbrains.PyCharm-Community.desktop', 'gedit.desktop', 'codeblocks.desktop', 'com.visualstudio.code.desktop']

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+maratona-meta (20210517.1) focal; urgency=medium
+
+  [ Bruno Ribas ]
+  * dconf/80-keyboards: Add `latam` layout and set `us` as default
+  * zera-home-icpc: Runs if there is no /home/icpc
+  * zera-home-icpc: Creates a random password for ICPC when cleaning
+
+  [ Davi Antônio da Silva Santos ]
+  * Remove eclipse from favourites
+  * Update configuration files for 20210517
+  * Update changelog for version 20210517.1
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Tue, 25 May 2021 21:01:49 -0300
+
 maratona-meta (20210517) focal; urgency=medium
 
   [ Guilherme Deusdará ]

--- a/maratona-editores-config/flatpak-consent.tar.xz
+++ b/maratona-editores-config/flatpak-consent.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b7c3d91ae5453f77e9897003f1c51b79ac3b9c7c645e8cd736907295b50c399
-size 98492416
+oid sha256:eeded2bc5e0ed4921a1c48291abebc8e23cefc285d317dae65310b1252b8cca3
+size 28268

--- a/maratona-editores-config/jetbrains-prefs.tar.xz
+++ b/maratona-editores-config/jetbrains-prefs.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd3c529e4c2cf8b4adf811579a33658507c1df2c5af867b24536de4aa4c32c18
-size 20480
+oid sha256:6273d34c44cf84d66a68e55bfc61a004fba8cdc042107841faff3e56e3bda910
+size 860


### PR DESCRIPTION
Adds all fixes since commit dbfbcb4: default keyboard is now us, with
options to change for Brazilian and Spanish; home cleaning scripts have
been improved, and configuration files have been updated.

- dconf/80-keyboards: Add `latam` layout and set `us` as default 
- zera-home-icpc: Runs if there is no /home/icpc
- zera-home-icpc: Creates a random password for ICPC when cleaning    
- Remove eclipse from favourites
- Compress uncompressed files
- Update configuration files for 20210517