### PR TITLE
Release version 20210517.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+maratona-meta (20210517.2) focal; urgency=medium
+
+  * Update maintainer, dependencies and descriptions
+    - updates maintainer's name and email
+    - adds VCS information
+    - adds firefox as a dependency from maratona-desktop
+    - updates the descriptions of maratona-conflitos, maratona-task-data and
+      maratona-flatpak-common (fixes Lintian warning
+      extended-description-contains-empty-paragraph, check issue #50)
+    - adds maratona-desktop as a dependency from maratona-desktop-latam
+  * Set exit on failure for postinst and postrm
+    - adds set -e for post installation and removal scripts in order to fix
+      Lintian maintainer-script-ignores-errors, check issue #50)
+    - modify maratona-usuario-icpc.postinst to eliminate indirect status
+      checks that would cause an abnormal execution
+  * Update machine-readable copyright file
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 28 Jun 2021 21:02:23 -0300
+
 maratona-meta (20210517.1) focal; urgency=medium
 
   [ Bruno Ribas ]

--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,16 @@
 Source: maratona-meta
 Section: metapackages
 Priority: optional
-Maintainer: Bruno Ribas <brunoribas@utfpr.edu.br>
+Maintainer: Bruno César Ribas <bruno.ribas@unb.br>
 Build-Depends: debhelper-compat (= 12)
+Vcs-Git: https://github.com/maratona-linux/maratona-meta.git
+Vcs-Browser: https://github.com/maratona-linux/maratona-meta
 
 Package: maratona-desktop
 Architecture: all
 Recommends: maratona-desktop-latam, maratona-submission
 Pre-Depends: maratona-essential
-Depends: ssh, maratona-conflitos, maratona-background, maratona-usuario-icpc, maratona-firewall, dconf-cli
+Depends: ssh, firefox, maratona-conflitos, maratona-background, maratona-usuario-icpc, maratona-firewall, dconf-cli
 Provides: maratona-linux-gconf-user-profile
 Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux
  Este pacote detém todas as dependências obrigatórias para transformar o
@@ -20,10 +22,11 @@ Description: Pacote Virtual que transforma o Ubuntu em Maratona Linux
 Package: maratona-conflitos
 Architecture: all
 Depends: dconf-cli
-Description: Pacote do Maraton Linux com os conflitos para a maratona
- Este pacote além de remover alguns pacotes desnecessários para a maratona
- também desabilita o funcionamento do:
-  - Acesso a usuário guest
+Description: Pacote do Maratona com restrições para o ambiente
+ Este desabilita o funcionamento do:
+  - ssh para o usuário icpc
+  - visualização da lista de usuários na tela de login
+  - notificações do Ubuntu
 
 Package: maratona-essential
 Architecture: all
@@ -50,25 +53,23 @@ Description: Pacote que cria um usuário icpc para o competidor da maratona
 Package: maratona-desktop-latam
 Architecture: all
 Pre-Depends: gnome-dictionary
-Depends: dictd, dict-freedict-eng-por, dict-freedict-eng-spa
+Depends: dictd, dict-freedict-eng-por, dict-freedict-eng-spa, maratona-desktop
 Description: Pacote que adiciona o gnome-dictionary para o ambiente maratona
  Esse pacote cria um servidor dictd local, no qual o gnome-dictionary faz uso
  deste.
- .
- É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 
 Package: maratona-task-data
 Architecture: all
 Depends: tasksel
 Description: Pacote que adiciona o maratona-desktop à lista de tasks do tasksel
- .
- É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
+ Este pacote instala uma task que instala o pacote maratona-desktop com
+ dependência no pacote ubuntu-desktop-minimal.
 
 Package: maratona-flatpak-common
 Architecture: all
 Depends: flatpak
-Description: Pacote Virtual com a função de instalação flatpak do maratona linux
- .
- É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
+Description: Pacote Virtual com a função de instalação flatpak do Maratona Linux
+ Este pacote instala o flatpak e scripts usados pelo Maratona Linux para
+ instalar programas empacotados nesse formato.
 
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,13 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: maratona-background
-Source: <url://example.com>
+Upstream-Name: maratona-meta
+Source: <https://github.com/maratona-linux/maratona-meta>
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2.0+
-
-Files: debian/*
-Copyright: 2016 Bruno Ribas <brunoribas@utfpr.edu.br>
+Copyright: 2016-2021 Bruno César Ribas <bruno.ribas@unb.br>
+           2017 cassiopc <cassiopc@gmail.com>
+           2021 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
+           2020-2021 Guilherme Antonio Deusdará Banci <guibanci@gmail.com>
+           2018 Wall Berg Morais <wallbergmirandamorais@gmail.com>
 License: GPL-2.0+
 
 License: GPL-2.0+
@@ -27,8 +26,3 @@ License: GPL-2.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/debian/maratona-conflitos.postinst
+++ b/debian/maratona-conflitos.postinst
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #removendo o autostart do update-notifier
 dpkg-divert --divert /etc/xdg/update-notifier.desktop-desativado.orig \

--- a/debian/maratona-conflitos.postrm
+++ b/debian/maratona-conflitos.postrm
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #recolocando o autostart do update-notifier
 dpkg-divert --rename --remove /etc/xdg/autostart/update-notifier.desktop

--- a/debian/maratona-desktop-latam.postrm
+++ b/debian/maratona-desktop-latam.postrm
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 dpkg-divert --package maratona-desktop-latam --remove --rename \
         --divert /usr/share/gdict-1.0/default.desktop.orig /usr/share/gdict-1.0/sources/default.desktop

--- a/debian/maratona-desktop-latam.preinst
+++ b/debian/maratona-desktop-latam.preinst
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 dpkg-divert --package maratona-desktop-latam --add --rename \
         --divert /usr/share/gdict-1.0/default.desktop.orig /usr/share/gdict-1.0/sources/default.desktop

--- a/debian/maratona-usuario-icpc.postinst
+++ b/debian/maratona-usuario-icpc.postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -e
 
-id -u icpc >/dev/null 2>/dev/null
-if [ $? == 0 ]; then
+if id -u icpc >/dev/null 2>/dev/null; then
   # Se o usuario existe, vai verificar os previlegios dele.
   # Se for root, vai abortar a instalação, caso contrario, irá mudar o grupo de
   # usuario dele.


### PR DESCRIPTION
* Update maintainer, dependencies and descriptions
  - updates maintainer's name and email
  - adds VCS information
  - adds firefox as a dependency from maratona-desktop
  - updates the descriptions of maratona-conflitos, maratona-task-data and 
    maratona-flatpak-common (fixes Lintian warning
    extended-description-contains-empty-paragraph, check issue #50)
  - adds maratona-desktop as a dependency from maratona-desktop-latam
* Set exit on failure for postinst and postrm
  - adds set -e for post installation and removal scripts in order to fix 
    Lintian maintainer-script-ignores-errors, check issue #50)
  - modify maratona-usuario-icpc.postinst to eliminate indirect status
    checks that would cause an abnormal execution
* Update machine-readable copyright file
  - updates licenses in `debian/copyright`