### PR TITLE
Release 20210517.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+maratona-meta (20210517.3) focal; urgency=medium
+
+  * Fix the installation of VSCode extensions
+    - pre-package the extensions instead of downloading them at the
+      installation
+    - drop Visual Studio Code Java extensions
+  * Enable specifying the package's version
+    - update the helper script to enforce a specific version of a flatpak to
+      be installed
+  * Update the Jetbrains IDE's preferences
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Tue, 15 Feb 2022 15:33:27 -0300
+
 maratona-meta (20210517.2) focal; urgency=medium
 
   * Update maintainer, dependencies and descriptions

--- a/flatpak-common-script/install_flatpak.sh
+++ b/flatpak-common-script/install_flatpak.sh
@@ -8,15 +8,70 @@ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flat
 
 try_install_flatpak() {
 	try=0
-	while [ $(flatpak list | grep $1 | wc -l) -eq 0 ] && [ $try -lt 3 ]; do
-		flatpak install flathub $1 -y
+	while [ "$(flatpak list | grep "$1" | wc -l)" -eq 0 ] && [ $try -lt 3 ]; do
+		flatpak install flathub "$1" -y
 	    try=$((try+1))
 	done
 
 	# In case of success, return 0. In case of failure, return 1.
-	if [ $(flatpak list | grep $1 | wc -l) -eq 0 ]; then
+	if [ "$(flatpak list | grep "$1" | wc -l)" -eq 0 ]; then
 		return 1
 	else
 		return 0
 	fi
-} 
+}
+
+# Tries to remove a flatpak
+# Arguments:
+# $1 - package name
+try_remove_flatpak() {
+	if flatpak remove --assumeyes "$1"; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# Tries to install an specific version of a flatpak
+# If no version is specified, installs the ropository's default
+# Arguments:
+# $1 - package name
+# $2 - package version
+# Return codes:
+# 0 - package successfully installed
+# 1 - package could not be installed
+# 2 - failed to install the required version
+# 3 - failed to install the required version and remove the current one
+try_install_flatpak_version() {
+	local try=0
+	local -r max_tries=3
+
+	if try_install_flatpak "$1"; then
+		# no version specified
+		if [ ! "$2" ]; then
+			return 0
+		fi
+
+		while ! flatpak update --assumeyes --commit="$2" "$1" && [ "${try}" -lt "${max_tries}" ]; do
+			try=$((try+1))
+		done
+
+		local current_ver
+		current_ver=$(flatpak info --show-commit "$1")
+		local ver_status=$?
+
+		if [ "${ver_status}" -ne 0 ]; then
+			if [ "${current_ver}" == "$2" ]; then
+				return 0
+			else
+				if try_remove_flatpak "$1"; then
+					return 2
+				else
+					return 3
+				fi
+			fi
+		fi
+	else
+		return 1
+	fi
+}

--- a/maratona-editores-config/flatpak-consent.tar.xz
+++ b/maratona-editores-config/flatpak-consent.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eeded2bc5e0ed4921a1c48291abebc8e23cefc285d317dae65310b1252b8cca3
-size 28268
+oid sha256:34fcf0f99a9d879bf3518f51cae2f0c3d591857854fde73c1c3c3263dee07fed
+size 23124

--- a/maratona-editores-config/jetbrains-prefs.tar.xz
+++ b/maratona-editores-config/jetbrains-prefs.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6273d34c44cf84d66a68e55bfc61a004fba8cdc042107841faff3e56e3bda910
+oid sha256:0d2a98c8c119842e3ae8c6267d7a9c57b374df0f70c933e65b4fbb4624d04453
 size 860

--- a/scripts-administrativos/zera-home-icpc
+++ b/scripts-administrativos/zera-home-icpc
@@ -62,10 +62,6 @@ for config in /usr/share/maratona-usuario-icpc/editores-config/*; do
   tar -xf $config -C /home/icpc/
 done
 
-# copiando arquivos das extenções do vscode
-mkdir -p /home/icpc/.var/app/com.visualstudio.code/data/vscode/extensions/
-cp -r /usr/share/maratona-vscode-extensions/* /home/icpc/.var/app/com.visualstudio.code/data/vscode/extensions/
-
 # criando arquivo para vscode não mostrar warning ao iniciar pela primeira vez
 mkdir -p /home/icpc/.var/app/com.visualstudio.code/config/
 touch /home/icpc/.var/app/com.visualstudio.code/config/flatpak-vscode-first-run
@@ -91,13 +87,17 @@ su icpc -c 'dbus-launch gio set /home/icpc/Desktop/kotlindoc.desktop "metadata::
 # Bloquear a execução do diálogo de boas vindas no primeiro login do usuário
 echo "yes" > /home/icpc/.config/gnome-initial-setup-done
 
-# Configurar JDK/JRE do sistema para IntelliJ e VSCode em Flatpak
-# Ambas IDEs podem acessar arquivos normais (filesystem=host)
+# Configurar JDK/JRE do sistema para IntelliJ
+# A IDE pode acessar arquivos normais (filesystem=host)
 # (ver https://docs.flatpak.org/en/latest/sandbox-permissions.html)
 FLATPAK_JAVA_PATH="/var/run/host/usr/lib/jvm/java-11-openjdk-amd64"
+
 # VSCode
-mkdir -p '/home/icpc/.var/app/com.visualstudio.code/config/Code/User/'
-echo -e "{\n\t\"java.home\": \"${FLATPAK_JAVA_PATH}\"\n}" > '/home/icpc/.var/app/com.visualstudio.code/config/Code/User/settings.json'
+# O caminho só existirá se o maratona-vscode-extensions estiver instalado
+if [ -d '/var/lib/maratona-vscode-extensions/extensions' ] ; then
+	mkdir -p '/home/icpc/.var/app/com.visualstudio.code/data/vscode/extensions/'
+	cp -R '/var/lib/maratona-vscode-extensions/extensions' '/home/icpc/.var/app/com.visualstudio.code/data/vscode'
+fi
 
 # IntelliJ
 # É normal o link aparecer quebrado, já que é um caminho usado apenas pelo Flatpak
@@ -108,7 +108,6 @@ ln -s "${FLATPAK_JAVA_PATH}" '/home/icpc/.jdks/java-11-openjdk-amd64'
 # pertence ao root, o que não deve acontecer.
 chown -R icpc:users ~icpc
 chmod 755 /home/icpc/Desktop/*
-
 
 for i in media mnt var opt tmp usr $(df|grep tmpfs|awk '{print $NF}'); do
   printf "Removing files from: /$i"
@@ -125,5 +124,8 @@ echo "."
 echo
 echo "Tudo feito."
 rm /etc/nologin
+
+# Garantir modificações no disco antes de sair
+sync
 
 exit 0


### PR DESCRIPTION
  * Fix the installation of VSCode extensions
    - pre-package the extensions instead of downloading them at the
      installation
    - drop Visual Studio Code Java extensions
  * Enable specifying the package's version
    - update the helper script to enforce a specific version of a flatpak to
      be installed
  * Update the Jetbrains IDE's preferences